### PR TITLE
To fix the bad gate way error by openbabel for 3d depict

### DIFF
--- a/app/Livewire/MoleculeDepict3d.php
+++ b/app/Livewire/MoleculeDepict3d.php
@@ -18,7 +18,7 @@ class MoleculeDepict3d extends Component
     #[Computed]
     public function source()
     {
-        return env('CM_API').'depict/3D?smiles='.urlencode($this->smiles).'&height='.$this->height.'&width='.$this->width.'&CIP='.$this->CIP.'&toolkit=openbabel';
+        return env('CM_API').'depict/3D?smiles='.urlencode($this->smiles).'&height='.$this->height.'&width='.$this->width.'&CIP='.$this->CIP.'&toolkit=rdkit';
     }
 
     public function render()


### PR DESCRIPTION
the request now goes to rdkit instead of opedbabel which was throwing bad gateway error.