### PR TITLE
feat(jetstream): enable read-only personal access tokens

### DIFF
--- a/app/Providers/JetstreamServiceProvider.php
+++ b/app/Providers/JetstreamServiceProvider.php
@@ -31,13 +31,9 @@ class JetstreamServiceProvider extends ServiceProvider
      */
     protected function configurePermissions(): void
     {
+        // Sanctum PAT abilities are scoped to read only. REST authorization uses Spatie via policies.
         Jetstream::defaultApiTokenPermissions(['read']);
 
-        Jetstream::permissions([
-            'create',
-            'read',
-            'update',
-            'delete',
-        ]);
+        Jetstream::permissions(['read']);
     }
 }

--- a/config/jetstream.php
+++ b/config/jetstream.php
@@ -60,7 +60,7 @@ return [
     'features' => [
         // Features::termsAndPrivacyPolicy(),
         Features::profilePhotos(),
-        // Features::api(),
+        Features::api(),
         // Features::teams(['invitations' => true]),
         Features::accountDeletion(),
     ],

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -37,6 +37,15 @@ POST /api/auth/login
 :::info
 The token is of **Bearer** type. This has to be supplied in the headers of the requests. In case you are using the [swagger UI of the API](https://coconut.naturalproducts.net/api-documentation), click on the **Authorize** button and provide the token as per the instruction.
 :::
+
+### Personal Access Tokens
+
+Verified users can create long-lived **Personal Access Tokens** from the web application: account menu → **Personal Access Tokens** (`/user/api-tokens`). Use the token in the `Authorization` header as `Bearer <token>`.
+
+- Sanctum token abilities are limited to **read** at the token layer.
+- What you can do on the API (search, mutate, delete, and so on) is controlled by **Spatie permissions** on your user account, enforced through Lomkit policies—not by the token ability checkboxes.
+- Login and register responses return a separate short-lived `auth_token`; personal access tokens are intended for scripts and integrations you name and manage yourself.
+
 ### Logout
 ```
 GET /api/auth/logout
@@ -102,7 +111,6 @@ Search Molecules using various attributes. There are two tables invovled in this
 ::: warning Note
 The fields in the *molecules* table can be accessed directly with their column names. The fields in the *properties* table are to be accessed prefixing them with the table name. Ex: **properties.field-name**.
 :::
-
 
 **Request Body Example (application/json):**
 ```json

--- a/tests/Feature/ApiTokenPermissionsTest.php
+++ b/tests/Feature/ApiTokenPermissionsTest.php
@@ -25,21 +25,24 @@ class ApiTokenPermissionsTest extends TestCase
         $token = $user->tokens()->create([
             'name' => 'Test Token',
             'token' => Str::random(40),
-            'abilities' => ['create', 'read'],
+            'abilities' => ['read'],
         ]);
 
         Livewire::test(ApiTokenManager::class)
             ->set(['managingPermissionsFor' => $token])
             ->set(['updateApiTokenForm' => [
                 'permissions' => [
+                    'read',
                     'delete',
                     'missing-permission',
                 ],
             ]])
             ->call('updateApiToken');
 
-        $this->assertTrue($user->fresh()->tokens->first()->can('delete'));
-        $this->assertFalse($user->fresh()->tokens->first()->can('read'));
+        $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
         $this->assertFalse($user->fresh()->tokens->first()->can('missing-permission'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('create'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('update'));
     }
 }

--- a/tests/Feature/CreateApiTokenTest.php
+++ b/tests/Feature/CreateApiTokenTest.php
@@ -26,7 +26,6 @@ class CreateApiTokenTest extends TestCase
                 'name' => 'Test Token',
                 'permissions' => [
                     'read',
-                    'update',
                 ],
             ]])
             ->call('createApiToken');
@@ -34,6 +33,7 @@ class CreateApiTokenTest extends TestCase
         $this->assertCount(1, $user->fresh()->tokens);
         $this->assertEquals('Test Token', $user->fresh()->tokens->first()->name);
         $this->assertTrue($user->fresh()->tokens->first()->can('read'));
+        $this->assertFalse($user->fresh()->tokens->first()->can('update'));
         $this->assertFalse($user->fresh()->tokens->first()->can('delete'));
     }
 }


### PR DESCRIPTION
## Summary

- Enable Jetstream `Features::api()` so verified users can manage personal access tokens at `/user/api-tokens` (account menu → Personal Access Tokens).
- Restrict Sanctum PAT abilities to **read** only; default new tokens to `read`.
- REST API authorization is unchanged: Lomkit policies + Spatie permissions (`delete_molecule`, etc.), not Sanctum ability middleware.

## Test plan

- [x] `phpunit --filter=ApiToken` (3 tests)
- [x] Log in as verified user → create PAT → use `Authorization: Bearer <token>` on `GET /api/molecules`
- [x] Confirm token UI shows only **read** permission
- [x] Confirm `DELETE /api/molecules` returns 403 for users without Spatie delete permissions

## Resolves
Closes #744