### PR TITLE
WIP: feat(collections): add collection versioning

### DIFF
--- a/app/Actions/Coconut/SearchMolecule.php
+++ b/app/Actions/Coconut/SearchMolecule.php
@@ -285,13 +285,23 @@ class SearchMolecule
     private function buildTagsStatement($offset)
     {
         if ($this->tagType == 'dataSource') {
-            $this->collection = Collection::where('title', $this->query)->first();
-            if ($this->collection) {
-                $query = $this->collection->molecules()
+            $matched = Collection::query()
+                ->where('title', $this->query)
+                ->where('is_latest', true)
+                ->first()
+                ?? Collection::where('title', $this->query)->first();
+            if ($matched) {
+                $latest = $matched->is_latest
+                    ? $matched
+                    : ($matched->lineageVersionsQuery()->where('is_latest', true)->first() ?? $matched);
+
+                $this->collection = $latest;
+
+                $query = $latest->molecules()
                     ->whereIn('molecules.id', function ($query) {
                         $query->select('molecule_id')
                             ->from('entries')
-                            ->where('collection_id', $this->collection->id)
+                            ->where('collection_id', $latest->id)
                             ->distinct();
                     });
 

--- a/app/Console/Commands/DashWidgetsRefresh.php
+++ b/app/Console/Commands/DashWidgetsRefresh.php
@@ -36,6 +36,7 @@ class DashWidgetsRefresh extends Command
             return DB::table('collections')
                 ->selectRaw('count(*) as count')
                 ->where('status', 'PUBLISHED')
+                ->where('is_latest', true)
                 ->get()[0]->count;
         });
         $this->info('Cache for collections refreshed.');

--- a/app/Console/Commands/ImportCollectionVersion.php
+++ b/app/Console/Commands/ImportCollectionVersion.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Collection;
+use App\Services\CollectionVersioning\CollectionVersionImporter;
+use Illuminate\Console\Command;
+
+class ImportCollectionVersion extends Command
+{
+    protected $signature = 'coconut:import-collection-version {new_collection_id : The new version collection ID}';
+
+    protected $description = 'Run the full collection version migration pipeline';
+
+    public function handle(CollectionVersionImporter $importer): int
+    {
+        $collection = Collection::query()->find($this->argument('new_collection_id'));
+        if (! $collection) {
+            $this->error('Collection not found.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $result = $importer->import($collection);
+            $this->info('Collection version migration completed.');
+            $this->table(array_keys($result), [array_values($result)]);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ImportEntries.php
+++ b/app/Console/Commands/ImportEntries.php
@@ -34,9 +34,12 @@ class ImportEntries extends Command
         $collection_id = $this->argument('collection_id');
 
         if (! is_null($collection_id)) {
-            $collections = Collection::where('id', $collection_id)->get();
+            $collections = Collection::query()->where('id', $collection_id)->eligibleForLegacyPipeline()->get();
         } else {
-            $collections = Collection::where('status', 'DRAFT')->get();
+            $collections = Collection::query()
+                ->where('status', 'DRAFT')
+                ->eligibleForLegacyPipeline()
+                ->get();
         }
 
         foreach ($collections as $collection) {

--- a/app/Console/Commands/PreviewCollectionVersion.php
+++ b/app/Console/Commands/PreviewCollectionVersion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Collection;
+use App\Services\CollectionVersioning\CollectionVersionImporter;
+use Illuminate\Console\Command;
+
+class PreviewCollectionVersion extends Command
+{
+    protected $signature = 'coconut:preview-collection-version {new_collection_id : The new version collection ID}';
+
+    protected $description = 'Preview SMILES diff counts for a collection version migration';
+
+    public function handle(CollectionVersionImporter $importer): int
+    {
+        $collection = Collection::query()->find($this->argument('new_collection_id'));
+        if (! $collection) {
+            $this->error('Collection not found.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $preview = $importer->preview($collection);
+            $this->table(array_keys($preview), [array_values($preview)]);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/app/Console/Commands/ProcessEntries.php
+++ b/app/Console/Commands/ProcessEntries.php
@@ -38,6 +38,9 @@ class ProcessEntries extends Command
             $i = 0;
 
             $collection = Collection::whereId($collectionId['collection_id'])->first();
+            if (! $collection || $collection->isVersionMigrationActive()) {
+                continue;
+            }
             $collection->jobs_status = 'PROCESSING';
             $collection->job_info = 'Processing entries using ChEMBL Pipeline.';
             $collection->save();

--- a/app/Filament/Dashboard/Resources/CollectionResource.php
+++ b/app/Filament/Dashboard/Resources/CollectionResource.php
@@ -166,6 +166,18 @@ class CollectionResource extends Resource
                         TextEntry::make('identifier')
                             ->label('Identifier')
                             ->placeholder('No identifier'),
+                        TextEntry::make('version')
+                            ->label('Version'),
+                        TextEntry::make('is_latest')
+                            ->label('Latest')
+                            ->formatStateUsing(fn ($state) => $state ? 'Yes' : 'No'),
+                        TextEntry::make('doi')
+                            ->label('Version DOI')
+                            ->placeholder('Not minted'),
+                        TextEntry::make('doi_base')
+                            ->label('Base DOI (latest)')
+                            ->state(fn (Collection $record) => $record->lineageRoot()->doi_base)
+                            ->placeholder('Not minted'),
                     ])
                     ->columns(2),
                 Section::make('Display Image')
@@ -217,6 +229,7 @@ class CollectionResource extends Resource
                         'EMBARGO' => 'warning',
                         'PUBLISHED' => 'success',
                         'REJECTED' => 'danger',
+                        'SUPERSEDED' => 'gray',
                         default => 'gray',
                     }),
             ])

--- a/app/Filament/Dashboard/Resources/CollectionResource/Pages/ViewCollection.php
+++ b/app/Filament/Dashboard/Resources/CollectionResource/Pages/ViewCollection.php
@@ -4,6 +4,11 @@ namespace App\Filament\Dashboard\Resources\CollectionResource\Pages;
 
 use App\Filament\Dashboard\Resources\CollectionResource;
 use App\Filament\Dashboard\Resources\CollectionResource\Widgets\CollectionStats;
+use App\Models\Collection;
+use App\Services\CollectionVersioning\CollectionVersionCreator;
+use App\Services\CollectionVersioning\CollectionVersionImporter;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewCollection extends ViewRecord
@@ -14,6 +19,82 @@ class ViewCollection extends ViewRecord
     {
         return [
             CollectionStats::class,
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('createNewVersion')
+                ->label('Create new version')
+                ->icon('heroicon-o-document-duplicate')
+                ->visible(fn (Collection $record) => $record->is_latest
+                    && $record->status === 'PUBLISHED'
+                    && ! $record->isVersionMigrationActive())
+                ->requiresConfirmation()
+                ->modalHeading('Create new collection version')
+                ->modalDescription('This clones metadata into a new DRAFT version with the same CNPC identifier. Import CSV entries, then use Preview and Process new version.')
+                ->action(function (Collection $record, CollectionVersionCreator $creator) {
+                    $new = $creator->createFrom($record);
+                    Notification::make()
+                        ->title('New version created')
+                        ->body("Version {$new->version} is ready for CSV import.")
+                        ->success()
+                        ->send();
+
+                    $this->redirect(CollectionResource::getUrl('view', ['record' => $new]));
+                }),
+            Action::make('previewVersionMigration')
+                ->label('Preview migration')
+                ->icon('heroicon-o-eye')
+                ->visible(fn (Collection $record) => $record->version_migration_status === Collection::VERSION_MIGRATION_PENDING)
+                ->action(function (Collection $record, CollectionVersionImporter $importer) {
+                    try {
+                        $preview = $importer->preview($record);
+                        Notification::make()
+                            ->title('Migration preview')
+                            ->body(sprintf(
+                                'Dropped: %d | Retained: %d | New: %d | Revoke candidates: %d',
+                                $preview['old_only_count'],
+                                $preview['retained_count'],
+                                $preview['new_only_count'],
+                                $preview['revoke_candidate_count'],
+                            ))
+                            ->info()
+                            ->send();
+                    } catch (\Throwable $e) {
+                        Notification::make()->title('Preview failed')->body($e->getMessage())->danger()->send();
+                    }
+                }),
+            Action::make('processNewVersion')
+                ->label('Process new version')
+                ->icon('heroicon-o-play')
+                ->color('success')
+                ->visible(fn (Collection $record) => in_array($record->version_migration_status, [
+                    Collection::VERSION_MIGRATION_PENDING,
+                    Collection::VERSION_MIGRATION_PROCESSING,
+                ], true))
+                ->requiresConfirmation()
+                ->modalHeading('Process collection version migration')
+                ->modalDescription('This validates entries, diffs by standardized SMILES, migrates live data, revokes dropped exclusive molecules, and archives the previous version.')
+                ->action(function (Collection $record, CollectionVersionImporter $importer) {
+                    try {
+                        $result = $importer->import($record);
+                        Notification::make()
+                            ->title('Version migration completed')
+                            ->body(sprintf(
+                                'Revoked: %d | Retained: %d | New: %d',
+                                $result['revoked'],
+                                $result['retained'],
+                                $result['new_only'],
+                            ))
+                            ->success()
+                            ->send();
+                        $this->redirect(CollectionResource::getUrl('view', ['record' => $record->fresh()]));
+                    } catch (\Throwable $e) {
+                        Notification::make()->title('Migration failed')->body($e->getMessage())->danger()->send();
+                    }
+                }),
         ];
     }
 }

--- a/app/Filament/Dashboard/Resources/CollectionResource/RelationManagers/EntriesRelationManager.php
+++ b/app/Filament/Dashboard/Resources/CollectionResource/RelationManagers/EntriesRelationManager.php
@@ -151,6 +151,10 @@ class EntriesRelationManager extends RelationManager
                     ->label('Reference ID')
                     ->searchable(),
                 TextColumn::make('status'),
+                TextColumn::make('is_archived')
+                    ->label('Archived')
+                    ->badge()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->filters([
                 SelectFilter::make('status')
@@ -165,11 +169,16 @@ class EntriesRelationManager extends RelationManager
             ->headerActions([
                 ImportAction::make()
                     ->importer(EntryImporter::class)
+                    ->hidden(fn () => $this->ownerRecord->status === 'SUPERSEDED')
                     ->options([
                         'collection_id' => $this->ownerRecord->id,
                     ]),
                 Action::make('process')
                     ->hidden(function () {
+                        if ($this->ownerRecord->isVersionMigrationActive()) {
+                            return true;
+                        }
+
                         return $this->ownerRecord->entries()->where('status', 'SUBMITTED')->count() < 1;
                     })
                     ->action(function () {
@@ -190,9 +199,11 @@ class EntriesRelationManager extends RelationManager
                 ViewAction::make()
                     ->iconButton(),
                 EditAction::make()
-                    ->iconButton(),
+                    ->iconButton()
+                    ->hidden(fn () => $this->ownerRecord->status === 'SUPERSEDED'),
                 DeleteAction::make()
-                    ->iconButton(),
+                    ->iconButton()
+                    ->hidden(fn () => $this->ownerRecord->status === 'SUPERSEDED'),
             ])
             ->toolbarActions([
                 BulkActionGroup::make([

--- a/app/Filament/Dashboard/Resources/CollectionResource/RelationManagers/MoleculesRelationManager.php
+++ b/app/Filament/Dashboard/Resources/CollectionResource/RelationManagers/MoleculesRelationManager.php
@@ -14,10 +14,16 @@ use Filament\Schemas\Schema;
 use Filament\Tables\Columns\ImageColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Model;
 
 class MoleculesRelationManager extends RelationManager
 {
     protected static string $relationship = 'molecules';
+
+    public static function canViewForRecord(Model $ownerRecord, string $pageClass): bool
+    {
+        return $ownerRecord->status !== 'SUPERSEDED';
+    }
 
     public function form(Schema $schema): Schema
     {

--- a/app/Filament/Dashboard/Widgets/DashboardStats.php
+++ b/app/Filament/Dashboard/Widgets/DashboardStats.php
@@ -24,7 +24,7 @@ class DashboardStats extends BaseWidget
         });
 
         $totalCollections = Cache::flexible('stats.collections', [172800, 259200], function () {
-            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->get()[0]->count;
+            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->where('is_latest', true)->get()[0]->count;
         });
 
         $uniqueOrganisms = Cache::flexible('stats.organisms', [172800, 259200], function () {

--- a/app/Helper.php
+++ b/app/Helper.php
@@ -75,6 +75,7 @@ function getCollectionStatuses()
         'EMBARGO' => 'Embargo',
         'PUBLISHED' => 'Published',
         'REJECTED' => 'Rejected',
+        'SUPERSEDED' => 'Superseded',
     ];
 }
 

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -18,18 +18,32 @@ class CollectionController extends Controller
         }
 
         $collection = Cache::flexible('collections.'.$id, [172800, 259200], function () use ($id) {
-            return Collection::where('identifier', $id)->first();
+            return Collection::query()
+                ->where('identifier', $id)
+                ->orderByDesc('is_latest')
+                ->orderByDesc('version')
+                ->first();
         });
 
         if (! $collection) {
             abort(404);
         }
 
+        $latest = $collection->is_latest
+            ? $collection
+            : ($collection->lineageVersionsQuery()->where('is_latest', true)->first() ?? $collection);
+
         $query = [
             'type' => 'tags',
-            'q' => str_replace(' ', '+', $collection->title),
+            'q' => str_replace(' ', '+', $latest->title),
             'tagType' => 'dataSource',
         ];
+
+        if ($request->has('version')) {
+            $query['version'] = (int) $request->query('version');
+        } elseif (! $collection->is_latest) {
+            $query['version'] = $collection->version;
+        }
 
         $baseUrl = config('app.url');
 

--- a/app/Livewire/CollectionList.php
+++ b/app/Livewire/CollectionList.php
@@ -41,6 +41,7 @@ class CollectionList extends Component
         // $search = strtolower($this->query ?? '');
         $query = Collection::query()
             ->where('status', 'PUBLISHED')
+            ->where('is_latest', true)
             ->where(function ($query) use ($search) {
                 $query->whereRaw('LOWER(title) ILIKE ?', ['%'.$search.'%'])
                     ->orWhereRaw('LOWER(description) ILIKE ?', ['%'.$search.'%']);

--- a/app/Livewire/CollectionRevokedCompounds.php
+++ b/app/Livewire/CollectionRevokedCompounds.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\CollectionVersionRevocation;
+use Livewire\Component;
+
+class CollectionRevokedCompounds extends Component
+{
+    public int $lineageRootId;
+
+    public bool $expanded = false;
+
+    public ?int $filterVersion = null;
+
+    public function mount(int $lineageRootId, ?int $filterVersion = null): void
+    {
+        $this->lineageRootId = $lineageRootId;
+        $this->filterVersion = $filterVersion;
+    }
+
+    public function toggle(): void
+    {
+        $this->expanded = ! $this->expanded;
+    }
+
+    public function render()
+    {
+        $query = CollectionVersionRevocation::query()
+            ->where('lineage_root_id', $this->lineageRootId)
+            ->with(['molecule', 'fromCollection'])
+            ->orderByDesc('revoked_at');
+
+        if ($this->filterVersion) {
+            $query->whereHas('fromCollection', fn ($q) => $q->where('version', $this->filterVersion));
+        }
+
+        $revocations = $query->get();
+
+        return view('livewire.collection-revoked-compounds', [
+            'revocations' => $revocations,
+            'count' => $revocations->count(),
+        ]);
+    }
+}

--- a/app/Livewire/CollectionVersionHistory.php
+++ b/app/Livewire/CollectionVersionHistory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Collection;
+use Livewire\Component;
+
+class CollectionVersionHistory extends Component
+{
+    public int $lineageRootId;
+
+    public ?int $selectedVersion = null;
+
+    public function mount(int $lineageRootId, ?int $selectedVersion = null): void
+    {
+        $this->lineageRootId = $lineageRootId;
+        $this->selectedVersion = $selectedVersion;
+    }
+
+    public function selectVersion(int $version): void
+    {
+        $this->selectedVersion = $version;
+    }
+
+    public function render()
+    {
+        $root = Collection::query()->findOrFail($this->lineageRootId);
+        $versions = $root->lineageVersionsQuery()->get();
+        $selected = $this->selectedVersion
+            ? $versions->firstWhere('version', $this->selectedVersion)
+            : $versions->firstWhere('is_latest', true);
+
+        return view('livewire.collection-version-history', [
+            'versions' => $versions,
+            'selected' => $selected,
+            'baseDoi' => $root->doi_base,
+        ]);
+    }
+}

--- a/app/Livewire/DataSources.php
+++ b/app/Livewire/DataSources.php
@@ -13,7 +13,13 @@ class DataSources extends Component
     public function mount()
     {
         $this->collections = Cache::flexible('collections', [172800, 259200], function () {
-            return Collection::where('promote', true)->orderBy('sort_order')->take(10)->get(['title', 'image'])->toArray();
+            return Collection::query()
+                ->where('promote', true)
+                ->where('is_latest', true)
+                ->orderBy('sort_order')
+                ->take(10)
+                ->get(['title', 'image'])
+                ->toArray();
         });
     }
 }

--- a/app/Livewire/Search.php
+++ b/app/Livewire/Search.php
@@ -46,6 +46,9 @@ class Search extends Component
     #[Url(as: 'status')]
     public $status = 'all';
 
+    #[Url(as: 'version')]
+    public ?int $version = null;
+
     public function placeholder()
     {
         return <<<'HTML'

--- a/app/Livewire/Stats.php
+++ b/app/Livewire/Stats.php
@@ -84,7 +84,7 @@ class Stats extends Component
             return DB::table('molecules')->selectRaw('count(*)')->whereRaw('active=true and NOT (is_parent=true AND has_variants=true)')->get()[0]->count;
         });
         $this->totalCollections = Cache::flexible('stats.collections', [172800, 259200], function () {
-            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->get()[0]->count;
+            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->where('is_latest', true)->get()[0]->count;
         });
         $this->uniqueOrganisms = Cache::flexible('stats.organisms', [172800, 259200], function () {
             return DB::table('organisms')->selectRaw('count(*)')->get()[0]->count;

--- a/app/Livewire/Welcome.php
+++ b/app/Livewire/Welcome.php
@@ -56,7 +56,7 @@ class Welcome extends Component
             return DB::table('molecules')->selectRaw('count(*)')->whereRaw('active=true and NOT (is_parent=true AND has_variants=true)')->get()[0]->count;
         });
         $this->totalCollections = Cache::flexible('stats.collections', [172800, 259200], function () {
-            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->get()[0]->count;
+            return DB::table('collections')->selectRaw('count(*)')->whereRaw("status = 'PUBLISHED'")->where('is_latest', true)->get()[0]->count;
         });
         $this->uniqueOrganisms = Cache::flexible('stats.organisms', [172800, 259200], function () {
             return DB::table('organisms')->selectRaw('count(*)')->get()[0]->count;

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Filament\Traits\MutatesCollectionFormData;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,7 +18,12 @@ use Spatie\Tags\HasTags;
 
 /**
  * @property string|null $doi
+ * @property string|null $doi_base
+ * @property string|null $doi_suffix
  * @property array|null $datacite_schema
+ * @property int $version
+ * @property bool $is_latest
+ * @property string|null $version_migration_status
  */
 class Collection extends Model implements Auditable, HasMedia
 {
@@ -28,14 +34,18 @@ class Collection extends Model implements Auditable, HasMedia
     use MutatesCollectionFormData;
     use \OwenIt\Auditing\Auditable;
 
+    public const VERSION_MIGRATION_PENDING = 'pending';
+
+    public const VERSION_MIGRATION_PROCESSING = 'processing';
+
+    public const VERSION_MIGRATION_COMPLETE = 'complete';
+
     protected static function booted()
     {
         static::creating(fn ($collection) => $collection->uuid = Str::uuid());
     }
 
     /**
-     * The attributes that are mass assignable.
-     *
      * @var array<int, string>
      */
     protected $fillable = [
@@ -50,48 +60,124 @@ class Collection extends Model implements Auditable, HasMedia
         'status',
         'release_date',
         'datacite_schema',
+        'parent_collection_id',
+        'version',
+        'is_latest',
+        'superseded_by_collection_id',
+        'superseded_at',
+        'version_migration_status',
+        'archived_entries_count',
+        'archived_molecules_count',
+        'doi_base',
+        'doi_suffix',
     ];
 
-    /**
-     * Get the license of the project.
-     *
-     * @return BelongsTo
-     */
-    public function license()
+    protected $casts = [
+        'is_latest' => 'boolean',
+        'superseded_at' => 'datetime',
+        'release_date' => 'datetime',
+    ];
+
+    public function license(): BelongsTo
     {
         return $this->belongsTo(License::class, 'license_id');
     }
 
-    /**
-     * Get all of the citations for the collection.
-     */
     public function citations(): MorphToMany
     {
         return $this->morphToMany(Citation::class, 'citable');
     }
 
-    /**
-     * Get all of the entries for the collection.
-     */
     public function entries(): HasMany
     {
         return $this->hasMany(Entry::class);
     }
 
-    /**
-     * Get the molecules associated with the collection.
-     */
     public function molecules(): BelongsToMany
     {
         return $this->belongsToMany(Molecule::class)->withPivot('url', 'reference', 'mol_filename', 'structural_comments')->withTimestamps();
     }
 
-    /**
-     * Get all of the reports for the collection.
-     */
     public function reports(): MorphToMany
     {
         return $this->morphToMany(Report::class, 'reportable');
+    }
+
+    public function parentCollection(): BelongsTo
+    {
+        return $this->belongsTo(Collection::class, 'parent_collection_id');
+    }
+
+    public function supersededBy(): BelongsTo
+    {
+        return $this->belongsTo(Collection::class, 'superseded_by_collection_id');
+    }
+
+    public function versionRevocations(): HasMany
+    {
+        return $this->hasMany(CollectionVersionRevocation::class, 'lineage_root_id');
+    }
+
+    public function lineageRoot(): self
+    {
+        return $this->parent_collection_id
+            ? self::query()->findOrFail($this->parent_collection_id)
+            : $this;
+    }
+
+    public function lineageRootId(): int
+    {
+        return $this->parent_collection_id ?? $this->id;
+    }
+
+    /**
+     * @return Builder<Collection>
+     */
+    public function lineageVersionsQuery(): Builder
+    {
+        $rootId = $this->lineageRootId();
+
+        return self::query()
+            ->where(function (Builder $q) use ($rootId) {
+                $q->where('id', $rootId)->orWhere('parent_collection_id', $rootId);
+            })
+            ->orderByDesc('version');
+    }
+
+    public function isVersionMigrationActive(): bool
+    {
+        return in_array($this->version_migration_status, [
+            self::VERSION_MIGRATION_PENDING,
+            self::VERSION_MIGRATION_PROCESSING,
+        ], true);
+    }
+
+    public function scopeEligibleForLegacyPipeline(Builder $query): Builder
+    {
+        return $query->where(function (Builder $q) {
+            $q->whereNull('version_migration_status')
+                ->orWhere('version_migration_status', self::VERSION_MIGRATION_COMPLETE);
+        });
+    }
+
+    public function isSuperseded(): bool
+    {
+        return $this->status === 'SUPERSEDED' || ! $this->is_latest;
+    }
+
+    public static function lineageDoiKey(string $identifier): string
+    {
+        return 'coconut.'.strtolower($identifier);
+    }
+
+    public function versionDoiSuffix(): string
+    {
+        return self::lineageDoiKey((string) $this->identifier).'.v'.$this->version;
+    }
+
+    public function baseDoiSuffix(): string
+    {
+        return self::lineageDoiKey((string) $this->identifier);
     }
 
     public function transformAudit(array $data): array

--- a/app/Models/CollectionVersionRevocation.php
+++ b/app/Models/CollectionVersionRevocation.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CollectionVersionRevocation extends Model
+{
+    protected $fillable = [
+        'lineage_root_id',
+        'from_collection_id',
+        'to_collection_id',
+        'entry_id',
+        'molecule_id',
+        'reference_id',
+        'standardized_canonical_smiles',
+        'revoked_at',
+        'reason',
+    ];
+
+    protected $casts = [
+        'revoked_at' => 'datetime',
+    ];
+
+    public function lineageRoot(): BelongsTo
+    {
+        return $this->belongsTo(Collection::class, 'lineage_root_id');
+    }
+
+    public function fromCollection(): BelongsTo
+    {
+        return $this->belongsTo(Collection::class, 'from_collection_id');
+    }
+
+    public function toCollection(): BelongsTo
+    {
+        return $this->belongsTo(Collection::class, 'to_collection_id');
+    }
+
+    public function entry(): BelongsTo
+    {
+        return $this->belongsTo(Entry::class);
+    }
+
+    public function molecule(): BelongsTo
+    {
+        return $this->belongsTo(Molecule::class);
+    }
+}

--- a/app/Models/Entry.php
+++ b/app/Models/Entry.php
@@ -19,6 +19,9 @@ class Entry extends Model implements Auditable
         'meta_data' => 'array',
         'synonyms' => 'array',
         'cm_data' => 'array',
+        'has_rdkit_smiles_change' => 'boolean',
+        'rdkit_restandardized_at' => 'datetime',
+        'is_archived' => 'boolean',
     ];
 
     /**
@@ -44,8 +47,11 @@ class Entry extends Model implements Auditable
         'has_stereocenters',
         'is_invalid',
         'cm_data',
+        'has_rdkit_smiles_change',
+        'rdkit_restandardized_at',
         'submission_type',
         'meta_data',
+        'is_archived',
     ];
 
     /**

--- a/app/Models/HasDOI.php
+++ b/app/Models/HasDOI.php
@@ -7,20 +7,118 @@ trait HasDOI
     public function generateDOI($doiService)
     {
         $doi_host = config('doi.datacite.host');
-        if (! is_null($doi_host)) {
-            $identifier = $this->getIdentifier($this, 'identifier');
-            if ($this->doi == null) {
-                $url = 'https://coconut.naturalproducts.net/collections/'.$identifier;
-                $attributes = $this->getMetadata();
-                $attributes['url'] = $url;
-                $doiResponse = $doiService->createDOI($identifier, $attributes);
-                $this->doi = $doiResponse['data']['id'];
-                $this->datacite_schema = $doiResponse;
-                $this->save();
-            }
-
+        if (is_null($doi_host)) {
+            return;
         }
 
+        if ($this->doi !== null) {
+            return;
+        }
+
+        if ($this instanceof Collection && $this->identifier) {
+            $this->generateVersionedCollectionDois($doiService);
+
+            return;
+        }
+
+        $identifier = $this->getIdentifier($this, 'identifier');
+        $url = $this->collectionLandingUrl($identifier);
+        $attributes = $this->getMetadata();
+        $attributes['url'] = $url;
+        $doiResponse = $doiService->createDOI($identifier, $attributes);
+        $this->doi = $doiResponse['data']['id'];
+        $this->datacite_schema = $doiResponse;
+        $this->save();
+    }
+
+    public function generateVersionedCollectionDois($doiService): void
+    {
+        if (! ($this instanceof Collection)) {
+            return;
+        }
+
+        $doi_host = config('doi.datacite.host');
+        if (is_null($doi_host)) {
+            return;
+        }
+
+        $identifier = (string) $this->identifier;
+        $versionSuffix = $this->versionDoiSuffix();
+        $baseSuffix = $this->baseDoiSuffix();
+        $root = $this->lineageRoot();
+
+        if ($this->doi === null) {
+            $versionUrl = $this->collectionLandingUrl($identifier, $this->version);
+            $attributes = $this->getMetadata();
+            $attributes['url'] = $versionUrl;
+            if ($root->doi_base) {
+                $attributes['relatedIdentifiers'] = array_merge($attributes['relatedIdentifiers'] ?? [], [
+                    [
+                        'relatedIdentifier' => $root->doi_base,
+                        'relatedIdentifierType' => 'DOI',
+                        'relationType' => 'IsVersionOf',
+                    ],
+                ]);
+            }
+
+            $doiResponse = $doiService->createDoiWithSuffix($versionSuffix, $attributes);
+            $this->doi = $doiResponse['data']['id'];
+            $this->doi_suffix = $versionSuffix;
+            $this->datacite_schema = $doiResponse;
+            $this->save();
+        }
+
+        if ($root->doi_base === null) {
+            $baseUrl = $this->collectionLandingUrl($identifier);
+            $baseAttributes = $this->getMetadata();
+            $baseAttributes['url'] = $baseUrl;
+            $baseAttributes['titles'] = [
+                ['title' => $this->title.' (latest)'],
+            ];
+            $baseResponse = $doiService->createDoiWithSuffix($baseSuffix, $baseAttributes);
+            $root->doi_base = $baseResponse['data']['id'];
+            $root->save();
+        } else {
+            $this->updateBaseDoiLanding($doiService, $root);
+        }
+    }
+
+    public function updateBaseDoiLanding($doiService, ?Collection $root = null): void
+    {
+        if (! ($this instanceof Collection)) {
+            return;
+        }
+
+        $root = $root ?? $this->lineageRoot();
+        if (! $root->doi_base) {
+            return;
+        }
+
+        $identifier = (string) $this->identifier;
+        $baseUrl = $this->collectionLandingUrl($identifier);
+        $related = [
+            [
+                'relatedIdentifier' => $this->doi,
+                'relatedIdentifierType' => 'DOI',
+                'relationType' => 'HasVersion',
+            ],
+        ];
+
+        $doiService->updateDOI($root->doi_base, [
+            'url' => $baseUrl,
+            'relatedIdentifiers' => $related,
+        ]);
+    }
+
+    protected function collectionLandingUrl(string $identifier, ?int $version = null): string
+    {
+        $base = rtrim(config('app.url', 'https://coconut.naturalproducts.net'), '/');
+        $url = $base.'/collections/'.$identifier;
+        if ($version !== null && $version > 1) {
+            $url .= '?version='.$version;
+        }
+
+        return $url;
     }
 
     public function getIdentifier($model, $key)
@@ -70,7 +168,7 @@ trait HasDOI
                 'schemeUri' => 'https://spdx.org/licenses/',
             ],
         ];
-        $publicationYear = explode('-', $this->created_at)[0];
+        $publicationYear = explode('-', (string) $this->created_at)[0];
         $subjects = [
             ['subject' => 'Natural Product',
                 'subjectScheme' => 'NCI Thesaurus OBO Edition',

--- a/app/Services/CollectionVersioning/CollectionVersionCreator.php
+++ b/app/Services/CollectionVersioning/CollectionVersionCreator.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use App\Models\Collection;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class CollectionVersionCreator
+{
+    public function createFrom(Collection $source): Collection
+    {
+        if (! $source->is_latest || $source->status !== 'PUBLISHED') {
+            throw new RuntimeException('Only the latest published collection can spawn a new version.');
+        }
+
+        if ($source->jobs_status === 'PROCESSING' || $source->jobs_status === 'QUEUED') {
+            throw new RuntimeException('Collection is still processing. Wait until jobs complete.');
+        }
+
+        $root = $source->lineageRoot();
+        $rootId = $root->id;
+
+        $activeSibling = Collection::query()
+            ->where(function ($q) use ($rootId) {
+                $q->where('id', $rootId)->orWhere('parent_collection_id', $rootId);
+            })
+            ->whereIn('version_migration_status', [
+                Collection::VERSION_MIGRATION_PENDING,
+                Collection::VERSION_MIGRATION_PROCESSING,
+            ])
+            ->exists();
+
+        if ($activeSibling) {
+            throw new RuntimeException('A version import is already in progress for this collection lineage.');
+        }
+
+        $nextVersion = (int) Collection::query()
+            ->where(function ($q) use ($rootId) {
+                $q->where('id', $rootId)->orWhere('parent_collection_id', $rootId);
+            })
+            ->max('version') + 1;
+
+        $new = $source->replicate([
+            'uuid',
+            'doi',
+            'doi_base',
+            'doi_suffix',
+            'datacite_schema',
+            'jobs_status',
+            'job_info',
+            'successful_entries',
+            'failed_entries',
+            'molecules_count',
+            'citations_count',
+            'organisms_count',
+            'geo_count',
+            'total_entries',
+            'release_date',
+            'superseded_by_collection_id',
+            'superseded_at',
+            'archived_entries_count',
+            'archived_molecules_count',
+        ]);
+
+        $new->parent_collection_id = $rootId;
+        $new->version = $nextVersion;
+        $new->is_latest = false;
+        $new->status = 'DRAFT';
+        $new->identifier = $source->identifier;
+        $new->slug = Str::slug($root->slug.'-v'.$nextVersion);
+        $new->version_migration_status = Collection::VERSION_MIGRATION_PENDING;
+        $new->jobs_status = 'INCURATION';
+        $new->job_info = '';
+        $new->save();
+
+        $tags = $source->tags()->get();
+        if ($tags->isNotEmpty()) {
+            $new->syncTags($tags);
+        }
+
+        return $new->fresh();
+    }
+}

--- a/app/Services/CollectionVersioning/CollectionVersionDiff.php
+++ b/app/Services/CollectionVersioning/CollectionVersionDiff.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use App\Models\Collection;
+use App\Models\Entry;
+use Illuminate\Support\Collection as SupportCollection;
+
+class CollectionVersionDiffResult
+{
+    /**
+     * @param  SupportCollection<string, int>  $oldOnlySmilesToMoleculeId
+     * @param  SupportCollection<string, int>  $retainedSmilesToMoleculeId
+     * @param  SupportCollection<int, string>  $newOnlySmiles
+     */
+    public function __construct(
+        public SupportCollection $oldOnlySmilesToMoleculeId,
+        public SupportCollection $retainedSmilesToMoleculeId,
+        public SupportCollection $newOnlySmiles,
+    ) {}
+
+    public function oldOnlyMoleculeIds(): array
+    {
+        return $this->oldOnlySmilesToMoleculeId->values()->unique()->values()->all();
+    }
+
+    public function retainedMoleculeIds(): array
+    {
+        return $this->retainedSmilesToMoleculeId->values()->unique()->values()->all();
+    }
+}
+
+class CollectionVersionDiff
+{
+    public function compare(Collection $oldCollection, Collection $newCollection): CollectionVersionDiffResult
+    {
+        $oldSmilesToMoleculeId = $this->oldSmilesToMoleculeIds($oldCollection);
+        $newSmiles = $this->newPassedSmiles($newCollection);
+
+        $oldOnly = $oldSmilesToMoleculeId->keys()->diff($newSmiles);
+        $retained = $oldSmilesToMoleculeId->keys()->intersect($newSmiles);
+        $newOnly = $newSmiles->diff($oldSmilesToMoleculeId->keys())->values();
+
+        return new CollectionVersionDiffResult(
+            $oldSmilesToMoleculeId->only($oldOnly->all()),
+            $oldSmilesToMoleculeId->only($retained->all()),
+            $newOnly,
+        );
+    }
+
+    public function preview(Collection $oldCollection, Collection $newCollection): array
+    {
+        $diff = $this->compare($oldCollection, $newCollection);
+
+        return [
+            'old_only_count' => $diff->oldOnlySmilesToMoleculeId->count(),
+            'retained_count' => $diff->retainedSmilesToMoleculeId->count(),
+            'new_only_count' => $diff->newOnlySmiles->count(),
+            'revoke_candidate_count' => count($diff->oldOnlyMoleculeIds()),
+            'old_only_sample' => $diff->oldOnlySmilesToMoleculeId->keys()->take(10)->values()->all(),
+            'new_only_sample' => $diff->newOnlySmiles->take(10)->values()->all(),
+        ];
+    }
+
+    /**
+     * @return SupportCollection<string, int>
+     */
+    protected function oldSmilesToMoleculeIds(Collection $oldCollection): SupportCollection
+    {
+        return Entry::query()
+            ->where('collection_id', $oldCollection->id)
+            ->whereNotNull('molecule_id')
+            ->whereNotNull('standardized_canonical_smiles')
+            ->get(['molecule_id', 'standardized_canonical_smiles'])
+            ->groupBy('standardized_canonical_smiles')
+            ->map(fn ($group) => (int) $group->first()->molecule_id);
+    }
+
+    /**
+     * @return SupportCollection<int, string>
+     */
+    protected function newPassedSmiles(Collection $newCollection): SupportCollection
+    {
+        return Entry::query()
+            ->where('collection_id', $newCollection->id)
+            ->where('status', 'PASSED')
+            ->whereNotNull('standardized_canonical_smiles')
+            ->pluck('standardized_canonical_smiles')
+            ->unique()
+            ->values();
+    }
+}

--- a/app/Services/CollectionVersioning/CollectionVersionImporter.php
+++ b/app/Services/CollectionVersioning/CollectionVersionImporter.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use App\Actions\Coconut\AssignDOI;
+use App\Models\Collection;
+use App\Models\Entry;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class CollectionVersionImporter
+{
+    public function __construct(
+        protected ValidateMoleculesBatchWaiter $validateWaiter,
+        protected CollectionVersionDiff $diff,
+        protected RevokeDroppedMolecules $revokeDropped,
+        protected StripCollectionProvenance $stripProvenance,
+        protected AssignDOI $assignDoi,
+    ) {}
+
+    public function import(Collection $newCollection): array
+    {
+        if ($newCollection->version_migration_status !== Collection::VERSION_MIGRATION_PENDING
+            && $newCollection->version_migration_status !== Collection::VERSION_MIGRATION_PROCESSING) {
+            throw new RuntimeException('Collection is not in a version migration state.');
+        }
+
+        $oldCollection = $this->resolveOldCollection($newCollection);
+        if (! $oldCollection) {
+            throw new RuntimeException('Could not resolve previous latest collection in lineage.');
+        }
+
+        $newCollection->update(['version_migration_status' => Collection::VERSION_MIGRATION_PROCESSING]);
+
+        try {
+            $this->validateWaiter->runAndWait($newCollection);
+
+            $diffResult = $this->diff->compare($oldCollection, $newCollection);
+
+            Artisan::call('coconut:import-molecules', ['collection_id' => $newCollection->id]);
+
+            $this->revokeDropped->revoke(
+                $diffResult->oldOnlyMoleculeIds(),
+                $oldCollection,
+                $newCollection,
+                $diffResult,
+            );
+
+            $this->stripProvenance->stripAllForCollection($oldCollection->id);
+
+            Artisan::call('coconut:enrich-molecules', ['collection_id' => $newCollection->id]);
+            Artisan::call('coconut:publish-molecules', ['collection_id' => $newCollection->id]);
+            $this->runPostPublishChain($newCollection->id);
+
+            $this->archiveOldCollection($oldCollection, $newCollection);
+            $this->publishNewCollection($newCollection, $oldCollection);
+
+            Cache::forget('collections.'.$newCollection->identifier);
+            if (Artisan::all()['coconut:cache'] ?? null) {
+                Artisan::call('coconut:cache');
+            }
+
+            return [
+                'old_collection_id' => $oldCollection->id,
+                'new_collection_id' => $newCollection->id,
+                'revoked' => count($diffResult->oldOnlyMoleculeIds()),
+                'retained' => count($diffResult->retainedMoleculeIds()),
+                'new_only' => $diffResult->newOnlySmiles->count(),
+            ];
+        } catch (\Throwable $e) {
+            $newCollection->update(['version_migration_status' => Collection::VERSION_MIGRATION_PENDING]);
+            throw $e;
+        }
+    }
+
+    public function preview(Collection $newCollection): array
+    {
+        $oldCollection = $this->resolveOldCollection($newCollection);
+        if (! $oldCollection) {
+            throw new RuntimeException('Could not resolve previous latest collection in lineage.');
+        }
+
+        return $this->diff->preview($oldCollection, $newCollection);
+    }
+
+    protected function resolveOldCollection(Collection $newCollection): ?Collection
+    {
+        $rootId = $newCollection->lineageRootId();
+
+        return Collection::query()
+            ->where(function ($q) use ($rootId) {
+                $q->where('id', $rootId)->orWhere('parent_collection_id', $rootId);
+            })
+            ->where('id', '!=', $newCollection->id)
+            ->where('is_latest', true)
+            ->first()
+            ?? Collection::query()
+                ->where(function ($q) use ($rootId) {
+                    $q->where('id', $rootId)->orWhere('parent_collection_id', $rootId);
+                })
+                ->where('id', '!=', $newCollection->id)
+                ->where('version', $newCollection->version - 1)
+                ->first();
+    }
+
+    protected function runPostPublishChain(int $collectionId): void
+    {
+        $commands = [
+            'coconut:generate-properties-auto',
+            'coconut:generate-coordinates-auto',
+            'coconut:npclassify',
+            'coconut:import-pubchem-data',
+            'coconut:fetch-cas-numbers',
+        ];
+
+        foreach ($commands as $command) {
+            if (Artisan::all()[$command] ?? null) {
+                Artisan::call($command, ['collection_id' => $collectionId]);
+            }
+        }
+    }
+
+    protected function archiveOldCollection(Collection $oldCollection, Collection $newCollection): void
+    {
+        $entriesCount = Entry::query()->where('collection_id', $oldCollection->id)->count();
+        $moleculesCount = DB::table('collection_molecule')->where('collection_id', $oldCollection->id)->count();
+
+        Entry::query()
+            ->where('collection_id', $oldCollection->id)
+            ->update(['is_archived' => true]);
+
+        $oldCollection->update([
+            'status' => 'SUPERSEDED',
+            'is_latest' => false,
+            'superseded_by_collection_id' => $newCollection->id,
+            'superseded_at' => now(),
+            'archived_entries_count' => $entriesCount,
+            'archived_molecules_count' => $moleculesCount,
+            'molecules_count' => 0,
+        ]);
+    }
+
+    protected function publishNewCollection(Collection $newCollection, Collection $oldCollection): void
+    {
+        $root = $newCollection->lineageRoot();
+
+        Collection::query()
+            ->where(function ($q) use ($root) {
+                $q->where('id', $root->id)->orWhere('parent_collection_id', $root->id);
+            })
+            ->where('id', '!=', $newCollection->id)
+            ->update(['is_latest' => false]);
+
+        $newCollection->update([
+            'status' => 'PUBLISHED',
+            'is_latest' => true,
+            'version_migration_status' => Collection::VERSION_MIGRATION_COMPLETE,
+            'release_date' => now(),
+        ]);
+
+        $this->assignDoi->assign($newCollection->fresh());
+        $newCollection->fresh()->updateBaseDoiLanding(app(\App\Services\DOI\DOIService::class), $root->fresh());
+    }
+}

--- a/app/Services/CollectionVersioning/RevokeDroppedMolecules.php
+++ b/app/Services/CollectionVersioning/RevokeDroppedMolecules.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use App\Models\Collection;
+use App\Models\CollectionVersionRevocation;
+use App\Models\Entry;
+use App\Models\Molecule;
+use Illuminate\Support\Facades\DB;
+
+class RevokeDroppedMolecules
+{
+    /**
+     * @param  array<int>  $moleculeIds
+     * @return array<int> Revoked molecule ids
+     */
+    public function revoke(
+        array $moleculeIds,
+        Collection $oldCollection,
+        Collection $newCollection,
+        CollectionVersionDiffResult $diff,
+    ): array {
+        $revoked = [];
+        $lineageRootId = $oldCollection->lineageRootId();
+        $lineageCollectionIds = $this->lineageCollectionIds($lineageRootId);
+
+        foreach ($moleculeIds as $moleculeId) {
+            if (! $this->isExclusiveToLineage($moleculeId, $lineageCollectionIds)) {
+                continue;
+            }
+
+            $molecule = Molecule::query()->find($moleculeId);
+            if (! $molecule) {
+                continue;
+            }
+
+            $molecule->status = 'REVOKED';
+            $molecule->active = false;
+            $molecule->comment = trim(($molecule->comment ?? '').' Revoked: dropped in collection version '.$newCollection->version.'.');
+            $molecule->save();
+
+            $entry = Entry::query()
+                ->where('collection_id', $oldCollection->id)
+                ->where('molecule_id', $moleculeId)
+                ->first();
+
+            $smiles = $diff->oldOnlySmilesToMoleculeId->search($moleculeId) ?: $entry?->standardized_canonical_smiles;
+
+            CollectionVersionRevocation::query()->create([
+                'lineage_root_id' => $lineageRootId,
+                'from_collection_id' => $oldCollection->id,
+                'to_collection_id' => $newCollection->id,
+                'entry_id' => $entry?->id,
+                'molecule_id' => $moleculeId,
+                'reference_id' => $entry?->reference_id,
+                'standardized_canonical_smiles' => is_string($smiles) ? $smiles : null,
+                'revoked_at' => now(),
+                'reason' => 'dropped_in_version_'.$newCollection->version,
+            ]);
+
+            $revoked[] = $moleculeId;
+        }
+
+        return $revoked;
+    }
+
+    /**
+     * @return array<int>
+     */
+    protected function lineageCollectionIds(int $lineageRootId): array
+    {
+        return Collection::query()
+            ->where(function ($q) use ($lineageRootId) {
+                $q->where('id', $lineageRootId)->orWhere('parent_collection_id', $lineageRootId);
+            })
+            ->pluck('id')
+            ->all();
+    }
+
+    /**
+     * @param  array<int>  $lineageCollectionIds
+     */
+    protected function isExclusiveToLineage(int $moleculeId, array $lineageCollectionIds): bool
+    {
+        $otherCollectionLinks = DB::table('collection_molecule')
+            ->where('molecule_id', $moleculeId)
+            ->whereNotIn('collection_id', $lineageCollectionIds)
+            ->exists();
+
+        if ($otherCollectionLinks) {
+            return false;
+        }
+
+        $organismRows = DB::table('molecule_organism')
+            ->where('molecule_id', $moleculeId)
+            ->get(['collection_ids']);
+
+        foreach ($organismRows as $row) {
+            $ids = json_decode($row->collection_ids ?? '[]', true) ?: [];
+            foreach ($ids as $collectionId) {
+                if (! in_array((int) $collectionId, $lineageCollectionIds, true)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+}

--- a/app/Services/CollectionVersioning/StripCollectionProvenance.php
+++ b/app/Services/CollectionVersioning/StripCollectionProvenance.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use Illuminate\Support\Facades\DB;
+
+class StripCollectionProvenance
+{
+    public function stripAllForCollection(int $oldCollectionId): void
+    {
+        $moleculeIds = DB::table('collection_molecule')
+            ->where('collection_id', $oldCollectionId)
+            ->pluck('molecule_id')
+            ->unique()
+            ->all();
+
+        foreach ($moleculeIds as $moleculeId) {
+            $this->stripForMolecule((int) $moleculeId, $oldCollectionId);
+        }
+
+        DB::table('citables')
+            ->where('citable_type', 'App\\Models\\Collection')
+            ->where('citable_id', $oldCollectionId)
+            ->delete();
+    }
+
+    public function stripForMolecule(int $moleculeId, int $oldCollectionId): void
+    {
+        DB::table('collection_molecule')
+            ->where('collection_id', $oldCollectionId)
+            ->where('molecule_id', $moleculeId)
+            ->delete();
+
+        $rows = DB::table('molecule_organism')
+            ->where('molecule_id', $moleculeId)
+            ->get();
+
+        foreach ($rows as $row) {
+            $metadata = json_decode($row->metadata ?? '{}', true) ?: [];
+            $cols = array_values(array_filter(
+                $metadata['cols'] ?? [],
+                fn ($col) => (int) ($col['id'] ?? 0) !== $oldCollectionId
+            ));
+
+            $collectionIds = array_values(array_filter(
+                json_decode($row->collection_ids ?? '[]', true) ?: [],
+                fn ($id) => (int) $id !== $oldCollectionId
+            ));
+
+            if (empty($cols) && empty($collectionIds)) {
+                DB::table('molecule_organism')->where('id', $row->id)->delete();
+
+                continue;
+            }
+
+            $metadata['cols'] = $cols;
+            $metadata['col_ids'] = array_values(array_filter(
+                $metadata['col_ids'] ?? [],
+                fn ($id) => (int) $id !== $oldCollectionId
+            ));
+
+            DB::table('molecule_organism')->where('id', $row->id)->update([
+                'metadata' => json_encode($metadata),
+                'collection_ids' => json_encode($collectionIds),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $entryDois = DB::table('entries')
+            ->where('collection_id', $oldCollectionId)
+            ->where('molecule_id', $moleculeId)
+            ->whereNotNull('doi')
+            ->pluck('doi')
+            ->flatMap(fn ($doi) => array_filter(array_map('trim', preg_split('/[|,]/', (string) $doi))))
+            ->unique()
+            ->all();
+
+        if (! empty($entryDois)) {
+            $citationIds = DB::table('citations')->whereIn('doi', $entryDois)->pluck('id');
+            if ($citationIds->isNotEmpty()) {
+                DB::table('citables')
+                    ->where('citable_type', 'App\\Models\\Molecule')
+                    ->where('citable_id', $moleculeId)
+                    ->whereIn('citation_id', $citationIds)
+                    ->delete();
+            }
+        }
+    }
+}

--- a/app/Services/CollectionVersioning/ValidateMoleculesBatchWaiter.php
+++ b/app/Services/CollectionVersioning/ValidateMoleculesBatchWaiter.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services\CollectionVersioning;
+
+use App\Models\Collection;
+use App\Models\Entry;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+class ValidateMoleculesBatchWaiter
+{
+    public function runAndWait(Collection $collection, int $maxWaitSeconds = 3600): void
+    {
+        Artisan::call('coconut:validate-molecules', ['collection_id' => $collection->id]);
+
+        $batch = $this->findLatestBatchForCollection($collection->id);
+        if (! $batch) {
+            $this->assertGateConditions($collection);
+
+            return;
+        }
+
+        $start = time();
+        while (! $batch->finished()) {
+            if ((time() - $start) > $maxWaitSeconds) {
+                throw new RuntimeException("Validation batch timed out for collection {$collection->id}.");
+            }
+            sleep(15);
+            $batch = Bus::findBatch($batch->id) ?? $batch;
+        }
+
+        if ($batch->hasFailures()) {
+            throw new RuntimeException("Validation batch failed for collection {$collection->id}: {$batch->failedJobs} jobs failed.");
+        }
+
+        $this->assertGateConditions($collection->fresh());
+    }
+
+    protected function findLatestBatchForCollection(int $collectionId): ?Batch
+    {
+        $record = DB::table('job_batches')
+            ->where('name', 'Validate Molecules '.$collectionId)
+            ->orderByDesc('created_at')
+            ->first();
+
+        if (! $record) {
+            return null;
+        }
+
+        return Bus::findBatch($record->id);
+    }
+
+    protected function assertGateConditions(Collection $collection): void
+    {
+        $submitted = Entry::query()
+            ->where('collection_id', $collection->id)
+            ->where('status', 'SUBMITTED')
+            ->count();
+
+        if ($submitted > 0) {
+            throw new RuntimeException("Collection {$collection->id} still has {$submitted} SUBMITTED entries after validation.");
+        }
+
+        $missingSmiles = Entry::query()
+            ->where('collection_id', $collection->id)
+            ->where('status', 'PASSED')
+            ->whereNull('standardized_canonical_smiles')
+            ->count();
+
+        if ($missingSmiles > 0) {
+            throw new RuntimeException("Collection {$collection->id} has {$missingSmiles} PASSED entries without standardized_canonical_smiles.");
+        }
+    }
+}

--- a/app/Services/DOI/DOIService.php
+++ b/app/Services/DOI/DOIService.php
@@ -8,9 +8,11 @@ interface DOIService
 
     public function createDOI($identifier, $attributes = []);
 
+    public function createDoiWithSuffix(string $suffix, array $metadata = []): array;
+
     public function getDOI($doi);
 
-    public function updateDOI($doi);
+    public function updateDOI($doi, $metadata = []);
 
     public function deleteDOI($doi);
 

--- a/app/Services/DOI/DataCite.php
+++ b/app/Services/DOI/DataCite.php
@@ -8,6 +8,10 @@ use GuzzleHttp\RequestOptions;
 
 class DataCite implements DOIService
 {
+    protected Client $client;
+
+    protected string $prefix;
+
     public function __construct()
     {
         $this->client = new Client([
@@ -20,9 +24,6 @@ class DataCite implements DOIService
         $this->prefix = Config::get('doi.'.Config::get('doi.default').'.prefix');
     }
 
-    /**
-     * Returns a list of DOIs
-     */
     public function getDOIs()
     {
         $prefix = Config::get('doi.'.Config::get('doi.default').'.prefix');
@@ -38,15 +39,23 @@ class DataCite implements DOIService
         return $response->getBody();
     }
 
+    /**
+     * @param  string  $identifier  Legacy: CNPC id or full suffix e.g. coconut.cnpc0070.v2
+     */
     public function createDOI($identifier, $metadata = [])
     {
-        $doi = $this->prefix.'/'.Config::get('app.name').'.'.$identifier;
-        $url = 'https://coconut.naturalproducts.net/collections/'.$identifier;
-        $suffix = Config::get('app.name').'.'.$identifier;
+        $suffix = $this->resolveSuffix($identifier);
+
+        return $this->createDoiWithSuffix($suffix, $metadata);
+    }
+
+    public function createDoiWithSuffix(string $suffix, array $metadata = []): array
+    {
+        $doi = $this->prefix.'/'.$suffix;
         $attributes = [
-            'doi' => $this->prefix.'/'.Config::get('app.name').'.'.$identifier,
+            'doi' => $doi,
             'prefix' => $this->prefix,
-            'suffix' => Config::get('app.name').'.'.$identifier,
+            'suffix' => $suffix,
             'publisher' => Config::get('app.name'),
             'publicationYear' => now()->format('Y'),
             'language' => 'en',
@@ -63,23 +72,12 @@ class DataCite implements DOIService
             ],
         ];
 
-        $response = $this->client->post('/dois',
-            [RequestOptions::JSON => $body]
-        );
-
-        $stream = $response->getBody();
-        $contents = $stream->getContents();
+        $response = $this->client->post('/dois', [RequestOptions::JSON => $body]);
+        $contents = $response->getBody()->getContents();
 
         return json_decode($contents, true);
     }
 
-    /**
-     * Update DataCite metadata based on DOI
-     *
-     * @param  string  $doi
-     * @param  array  $metadata
-     * @return array $contents
-     */
     public function updateDOI($doi, $metadata = [])
     {
         $attributes = [];
@@ -94,15 +92,10 @@ class DataCite implements DOIService
             ],
         ];
 
-        $response = $this->client->put('/dois/'.urlencode($doi),
-            [RequestOptions::JSON => $body]
-        );
+        $response = $this->client->put('/dois/'.urlencode($doi), [RequestOptions::JSON => $body]);
+        $contents = $response->getBody()->getContents();
 
-        $stream = $response->getBody();
-        $contents = $stream->getContents();
-        $contents = json_decode($contents, true);
-
-        return $contents;
+        return json_decode($contents, true);
     }
 
     public function deleteDOI($doi)
@@ -117,5 +110,14 @@ class DataCite implements DOIService
         $response = $this->client->get('/dois/'.urlencode($doi).'/activities');
 
         return $response->getBody();
+    }
+
+    protected function resolveSuffix(string $identifier): string
+    {
+        if (str_contains($identifier, '.')) {
+            return $identifier;
+        }
+
+        return Config::get('app.name').'.'.$identifier;
     }
 }

--- a/database/migrations/2026_06_08_000001_add_collection_versioning_columns.php
+++ b/database/migrations/2026_06_08_000001_add_collection_versioning_columns.php
@@ -1,0 +1,91 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('collections', function (Blueprint $table) {
+            $table->foreignId('parent_collection_id')->nullable()->after('license_id')->constrained('collections')->nullOnDelete();
+            $table->unsignedSmallInteger('version')->default(1)->after('parent_collection_id');
+            $table->boolean('is_latest')->default(true)->after('version');
+            $table->foreignId('superseded_by_collection_id')->nullable()->after('is_latest')->constrained('collections')->nullOnDelete();
+            $table->timestamp('superseded_at')->nullable()->after('superseded_by_collection_id');
+            $table->string('version_migration_status', 32)->nullable()->after('superseded_at');
+            $table->unsignedInteger('archived_entries_count')->nullable()->after('version_migration_status');
+            $table->unsignedInteger('archived_molecules_count')->nullable()->after('archived_entries_count');
+            $table->string('doi_base')->nullable()->after('doi');
+            $table->string('doi_suffix')->nullable()->after('doi_base');
+
+            $table->unique(['identifier', 'version']);
+            $table->index(['parent_collection_id', 'version']);
+            $table->index('is_latest');
+        });
+
+        Schema::table('entries', function (Blueprint $table) {
+            $table->boolean('is_archived')->default(false)->after('status');
+        });
+
+        Schema::create('collection_version_revocations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('lineage_root_id')->constrained('collections')->cascadeOnDelete();
+            $table->foreignId('from_collection_id')->constrained('collections')->cascadeOnDelete();
+            $table->foreignId('to_collection_id')->constrained('collections')->cascadeOnDelete();
+            $table->foreignId('entry_id')->nullable()->constrained('entries')->nullOnDelete();
+            $table->foreignId('molecule_id')->nullable()->constrained('molecules')->nullOnDelete();
+            $table->longText('reference_id')->nullable();
+            $table->longText('standardized_canonical_smiles')->nullable();
+            $table->timestamp('revoked_at');
+            $table->string('reason')->nullable();
+            $table->timestamps();
+
+            $table->index('lineage_root_id');
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE collections DROP CONSTRAINT IF EXISTS collections_status_check');
+            DB::statement("ALTER TABLE collections ADD CONSTRAINT collections_status_check CHECK (status::text = ANY (ARRAY['DRAFT'::text, 'REVIEW'::text, 'EMBARGO'::text, 'PUBLISHED'::text, 'REJECTED'::text, 'SUPERSEDED'::text]))");
+        }
+
+        DB::table('collections')->update([
+            'version' => 1,
+            'is_latest' => true,
+        ]);
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE collections DROP CONSTRAINT IF EXISTS collections_status_check');
+            DB::statement("ALTER TABLE collections ADD CONSTRAINT collections_status_check CHECK (status::text = ANY (ARRAY['DRAFT'::text, 'REVIEW'::text, 'EMBARGO'::text, 'PUBLISHED'::text, 'REJECTED'::text]))");
+        }
+
+        Schema::dropIfExists('collection_version_revocations');
+
+        Schema::table('entries', function (Blueprint $table) {
+            $table->dropColumn('is_archived');
+        });
+
+        Schema::table('collections', function (Blueprint $table) {
+            $table->dropUnique(['identifier', 'version']);
+            $table->dropIndex(['parent_collection_id', 'version']);
+            $table->dropIndex(['is_latest']);
+            $table->dropConstrainedForeignId('parent_collection_id');
+            $table->dropConstrainedForeignId('superseded_by_collection_id');
+            $table->dropColumn([
+                'version',
+                'is_latest',
+                'superseded_at',
+                'version_migration_status',
+                'archived_entries_count',
+                'archived_molecules_count',
+                'doi_base',
+                'doi_suffix',
+            ]);
+        });
+    }
+};

--- a/docs/collection-submission.md
+++ b/docs/collection-submission.md
@@ -82,3 +82,13 @@ After creating an empty collection, an **"Entries"** pane becomes available at t
 9. **Publish the Compounds:**
     - If at least one compound passed the process, you will see the **"Publish"** button. Clicking this will publish the compounds that passed processing.
     > **Info:** After publishing, the collection status changes from **"DRAFT"** to **"PUBLISHED."** Only the compounds with status **"PASSED"** will be visible to everyone on the COCONUT platform.
+
+## Importing a new version of an existing collection
+
+For published collections, curators can release an updated dataset without losing audit history:
+
+1. Open the latest published collection and choose **Create new version**.
+2. Import the new CSV into the new DRAFT version (same CNPC identifier; new internal version row).
+3. Use **Preview migration** to review dropped, retained, and new compound counts (comparison uses standardized isomeric canonical SMILES after CM pre-processing).
+4. Run **Process new version** to validate entries, migrate live data to the new version, revoke compounds dropped exclusively from this source, and archive the previous version (entries kept read-only for audit).
+5. Version DOIs follow `10.71606/coconut.cnpc####.vN`; the base DOI `10.71606/coconut.cnpc####` always resolves to the latest release on the public collection page.

--- a/resources/scripts/python/exports/query_with_collection.sql
+++ b/resources/scripts/python/exports/query_with_collection.sql
@@ -77,7 +77,7 @@ molecule_collections AS (
     INNER JOIN 
         collection_molecule cm ON m.id = cm.molecule_id
     INNER JOIN 
-        collections c ON cm.collection_id = c.id
+        collections c ON cm.collection_id = c.id AND c.is_latest = TRUE
     WHERE 
         m.identifier IS NOT NULL 
         AND m.active = TRUE 

--- a/resources/views/livewire/collection-revoked-compounds.blade.php
+++ b/resources/views/livewire/collection-revoked-compounds.blade.php
@@ -1,0 +1,39 @@
+@if ($count > 0)
+    <div class="mt-8 border-t border-gray-200 pt-8">
+        <button type="button" wire:click="toggle" class="flex w-full items-center justify-between text-left">
+            <h2 class="text-xl font-semibold text-gray-900">Revoked compounds ({{ $count }})</h2>
+            <span class="text-sm text-gray-500">{{ $expanded ? 'Hide' : 'Show' }}</span>
+        </button>
+        <p class="mt-2 text-sm text-gray-600">
+            Compounds removed during a collection version update. They are no longer active for this source in the current release.
+        </p>
+
+        @if ($expanded)
+            <ul class="mt-4 space-y-4">
+                @foreach ($revocations as $revocation)
+                    <li class="rounded-lg border border-gray-200 p-4 text-sm">
+                        <div class="flex flex-wrap gap-4">
+                            @if ($revocation->standardized_canonical_smiles)
+                                <img
+                                    src="{{ config('services.cheminf.api_url') }}depict/2D?smiles={{ urlencode($revocation->standardized_canonical_smiles) }}&height=120&width=120"
+                                    alt="Structure"
+                                    class="h-28 w-28 rounded border border-gray-100"
+                                />
+                            @endif
+                            <div>
+                                <p><span class="font-medium">Reference:</span> {{ $revocation->reference_id ?? '—' }}</p>
+                                <p><span class="font-medium">Dropped in:</span> v{{ $revocation->fromCollection?->version }} → newer version</p>
+                                <p><span class="font-medium">Revoked:</span> {{ $revocation->revoked_at?->format('Y-m-d') }}</p>
+                                @if ($revocation->molecule?->identifier)
+                                    <p class="mt-1">
+                                        <a href="{{ url('/molecules/'.$revocation->molecule->identifier) }}" class="text-blue-600 underline">View molecule</a>
+                                    </p>
+                                @endif
+                            </div>
+                        </div>
+                    </li>
+                @endforeach
+            </ul>
+        @endif
+    </div>
+@endif

--- a/resources/views/livewire/collection-version-history.blade.php
+++ b/resources/views/livewire/collection-version-history.blade.php
@@ -1,0 +1,67 @@
+<div class="mt-8 border-t border-gray-200 pt-8">
+    <h2 class="text-xl font-semibold text-gray-900">Version history</h2>
+    @if ($baseDoi)
+        <p class="mt-2 text-sm text-gray-600">
+            Latest DOI:
+            <a href="https://doi.org/{{ $baseDoi }}" class="text-blue-600 underline" target="_blank" rel="noopener">{{ $baseDoi }}</a>
+        </p>
+    @endif
+
+    <div class="mt-4 overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200 text-sm">
+            <thead class="bg-gray-50">
+                <tr>
+                    <th class="px-3 py-2 text-left font-medium text-gray-700">Version</th>
+                    <th class="px-3 py-2 text-left font-medium text-gray-700">Status</th>
+                    <th class="px-3 py-2 text-left font-medium text-gray-700">DOI</th>
+                    <th class="px-3 py-2 text-left font-medium text-gray-700">Released</th>
+                    <th class="px-3 py-2 text-left font-medium text-gray-700">Entries</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100">
+                @foreach ($versions as $version)
+                    <tr class="@if($selected && $selected->id === $version->id) bg-blue-50 @endif">
+                        <td class="px-3 py-2">
+                            <button type="button" wire:click="selectVersion({{ $version->version }})" class="text-blue-600 hover:underline">
+                                v{{ $version->version }}
+                            </button>
+                        </td>
+                        <td class="px-3 py-2">
+                            @if ($version->is_latest)
+                                <span class="rounded bg-green-100 px-2 py-0.5 text-green-800">Current</span>
+                            @else
+                                <span class="rounded bg-gray-100 px-2 py-0.5 text-gray-700">Superseded</span>
+                            @endif
+                        </td>
+                        <td class="px-3 py-2">
+                            @if ($version->doi)
+                                <a href="https://doi.org/{{ $version->doi }}" class="text-blue-600 underline" target="_blank" rel="noopener">{{ $version->doi }}</a>
+                            @else
+                                —
+                            @endif
+                        </td>
+                        <td class="px-3 py-2">{{ $version->release_date?->format('Y-m-d') ?? $version->superseded_at?->format('Y-m-d') ?? '—' }}</td>
+                        <td class="px-3 py-2">{{ $version->is_latest ? $version->total_entries : ($version->archived_entries_count ?? $version->total_entries) }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+
+    @if ($selected && ! $selected->is_latest)
+        <p class="mt-4 rounded-md bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            You are viewing metadata for <strong>v{{ $selected->version }}</strong>.
+            <a href="?" class="font-semibold underline">Jump to current version</a>
+        </p>
+    @endif
+
+    @if ($selected)
+        <div class="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-gray-700">
+            <p class="font-medium text-gray-900">{{ $selected->title }} (v{{ $selected->version }})</p>
+            <p class="mt-2">{{ $selected->description }}</p>
+            @if ($selected->url)
+                <p class="mt-2"><a href="{{ $selected->url }}" class="text-blue-600 underline" target="_blank" rel="noopener">Source URL</a></p>
+            @endif
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/search.blade.php
+++ b/resources/views/livewire/search.blade.php
@@ -30,17 +30,31 @@
                     $currentMonthYear = now()->format('m-Y');
                 @endphp
 
-                @if ($collection->doi)
-                DOI: <a href="https://doi.org/{{$collection->doi}}" 
+                @php
+                    $displayDoi = $collection->is_latest
+                        ? ($collection->lineageRoot()->doi_base ?? $collection->doi)
+                        : $collection->doi;
+                @endphp
+                @if ($displayDoi)
+                DOI: <a href="https://doi.org/{{ $displayDoi }}"
                 class="mt-4 inline-block text-sm text-blue-600 underline">
-                    {{ $collection->doi }}
+                    {{ $displayDoi }}
                 </a><br/>
                 @endif
-                
-                <a href="https://coconut.s3.uni-jena.de/prod/downloads/{{ $currentYearMonth }}/collections/{{ $slug }}-{{ $currentMonthYear }}.zip" 
+
+                <a href="https://coconut.s3.uni-jena.de/prod/downloads/{{ $currentYearMonth }}/collections/{{ $slug }}-{{ $currentMonthYear }}.zip"
                 class="mt-4 inline-block text-sm text-blue-600 underline">
                     Download Collection (SDF) <span aria-hidden="true">→</span>
                 </a>
+
+                <livewire:collection-version-history
+                    :lineage-root-id="$collection->lineageRootId()"
+                    :selected-version="$version"
+                />
+                <livewire:collection-revoked-compounds
+                    :lineage-root-id="$collection->lineageRootId()"
+                    :filter-version="$version"
+                />
             </div>
         @elseif ($tagType == 'organisms' && $organisms)
             <div x-data="{ showAll: false }" class="mx-auto max-w-7xl px-4 pb-8 sm:px-6 lg:px-8">

--- a/tests/Unit/CollectionVersionDiffTest.php
+++ b/tests/Unit/CollectionVersionDiffTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Collection;
+use App\Models\Entry;
+use App\Models\Molecule;
+use App\Services\CollectionVersioning\CollectionVersionDiff;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CollectionVersionDiffTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_compares_standardized_canonical_smiles(): void
+    {
+        $old = Collection::factory()->create([
+            'version' => 1,
+            'is_latest' => true,
+            'identifier' => 'CNPC_TEST_1',
+        ]);
+        $new = Collection::factory()->create([
+            'parent_collection_id' => $old->id,
+            'version' => 2,
+            'is_latest' => false,
+            'identifier' => 'CNPC_TEST_1',
+        ]);
+
+        $molA = Molecule::query()->create(['canonical_smiles' => 'AAA', 'standard_inchi' => 'InChI-A']);
+        $molB = Molecule::query()->create(['canonical_smiles' => 'BBB', 'standard_inchi' => 'InChI-B']);
+
+        foreach ([
+            ['collection_id' => $old->id, 'molecule_id' => $molA->id, 'smiles' => 'AAA'],
+            ['collection_id' => $old->id, 'molecule_id' => $molB->id, 'smiles' => 'BBB'],
+            ['collection_id' => $new->id, 'molecule_id' => null, 'smiles' => 'BBB', 'status' => 'PASSED'],
+            ['collection_id' => $new->id, 'molecule_id' => null, 'smiles' => 'CCC', 'status' => 'PASSED'],
+        ] as $row) {
+            Entry::query()->create([
+                'collection_id' => $row['collection_id'],
+                'molecule_id' => $row['molecule_id'],
+                'standardized_canonical_smiles' => $row['smiles'],
+                'canonical_smiles' => $row['smiles'],
+                'status' => $row['status'] ?? 'IMPORTED',
+                'uuid' => (string) Str::uuid(),
+            ]);
+        }
+
+        $diff = app(CollectionVersionDiff::class)->compare($old, $new);
+
+        $this->assertTrue($diff->oldOnlySmilesToMoleculeId->has('AAA'));
+        $this->assertTrue($diff->retainedSmilesToMoleculeId->has('BBB'));
+        $this->assertTrue($diff->newOnlySmiles->contains('CCC'));
+    }
+}

--- a/tests/Unit/LegacySchedulerVersionGuardTest.php
+++ b/tests/Unit/LegacySchedulerVersionGuardTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Collection;
+use App\Models\Entry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class LegacySchedulerVersionGuardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_collections_in_version_migration_are_not_eligible_for_legacy_pipeline(): void
+    {
+        $pending = Collection::factory()->create([
+            'version_migration_status' => Collection::VERSION_MIGRATION_PENDING,
+            'identifier' => 'CNPC_PENDING',
+            'version' => 2,
+        ]);
+
+        $normal = Collection::factory()->create([
+            'version_migration_status' => null,
+            'identifier' => 'CNPC_NORMAL',
+            'version' => 1,
+        ]);
+
+        $eligible = Collection::query()->eligibleForLegacyPipeline()->pluck('id')->all();
+
+        $this->assertContains($normal->id, $eligible);
+        $this->assertNotContains($pending->id, $eligible);
+    }
+}


### PR DESCRIPTION
## Summary

- Add collection lineage versioning: new `collections` row per release with shared CNPC identifier, `is_latest` flag, and `SUPERSEDED` audit-only prior versions
- Implement curator workflow via Filament (create version → import CSV → preview → process) backed by `CollectionVersionImporter` orchestration (validate → SMILES diff → import → revoke exclusives → enrich/publish → archive old → mint DOIs)
- Scope public search, stats, exports, and collection pages to latest published versions; show version history and revoked compounds on data source pages

## Commits

| Commit | Description |
|--------|-------------|
| `feat(collections): add versioning schema and models` | Migration, models, SUPERSEDED status |
| `feat(collections): add version migration orchestration services` | Diff, revoke, strip, waiter, importer |
| `feat(collections): add version import and preview artisan commands` | CLI entry points |
| `feat(doi): support versioned and base DataCite DOI suffixes` | `.vN` and base DOI |
| `fix(scheduler): skip collections during active version migration` | Legacy scheduler guard |
| `feat(filament): add collection version management actions` | Dashboard UI |
| `feat(collections): add public version history and revoked compounds UI` | Public pages |
| `feat(search): scope stats, search, and exports to latest collections` | `is_latest` filters |
| `test(collections): add version diff and scheduler guard coverage` | Unit tests |
| `docs(collections): document version migration curator workflow` | Docs |

## Test plan

- [ ] Run migration: `./vendor/bin/sail artisan migrate`
- [ ] Run unit tests: `./vendor/bin/sail test --filter='CollectionVersionDiff|LegacySchedulerVersionGuard'`
- [ ] Create new version from a published collection in Filament dashboard
- [ ] Import CSV entries, preview migration counts, process new version end-to-end
- [ ] Verify old collection is `SUPERSEDED` with archived entries; new collection is `PUBLISHED` and `is_latest`
- [ ] Confirm public collection page shows version history and revoked compounds when applicable
- [ ] Confirm search/stats/exports only surface latest published collections
- [ ] Verify versioned DOIs (`.vN`) and base DOI minting via DataCite (staging)

## Notes

- **WIP** — pending full integration testing with Horizon/redis for validate-molecules batch
- Unrelated local changes (Rdkit migration, docker-compose, package-lock) intentionally excluded from this branch